### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,4 +1,6 @@
 name: Cypress Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brunopulis/personal-site/security/code-scanning/1](https://github.com/brunopulis/personal-site/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions:` block to the workflow or to the job that limits the permissions as much as possible while ensuring the workflow works. Since the workflow as pictured only checks out code and runs Cypress (which does not require write permissions to the repository), the minimal sensible setting is `contents: read`. Place this block at the top level of the workflow (directly under the name or `on:` block) to set defaults for all jobs. No functional change will occur; this is a security hardening.

Specifically: Edit `.github/workflows/cypress.yml` and add:
```yaml
permissions:
  contents: read
```
after the `name: Cypress Tests` line, before the `on:` block.

No additional methods, imports, or library dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
