### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,4 +1,6 @@
 name: Accessibility Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brunopulis/personal-site/security/code-scanning/2](https://github.com/brunopulis/personal-site/security/code-scanning/2)

To fix the problem, we need to add a `permissions` block to the workflow file `.github/workflows/a11y.yml`, either at the root of the workflow or scoped to the relevant job (`a11y`). In this case, since no steps require write permissions, the most secure minimal setting is `contents: read`. This can go at the root level (affecting all jobs), or beneath the `a11y:` job definition to scope it more tightly. Since the workflow only contains a single job, putting it at the root is clearer and future-proofs against new jobs being added. Edit the file `.github/workflows/a11y.yml`, adding the following block right after the `name:` (before `on:`):

```yaml
permissions:
  contents: read
```

No further code changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
