### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/scripts/content/books-json-to-md.js
+++ b/scripts/content/books-json-to-md.js
@@ -39,7 +39,7 @@ function slugify(text) {
  */
 function escapeYaml(str) {
   if (!str) return '';
-  return str.replace(/"/g, '\\"');
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/brunopulis/personal-site/security/code-scanning/10](https://github.com/brunopulis/personal-site/security/code-scanning/10)

To properly escape double-quoted YAML string values, both backslashes (`\`) and double quotes (`"`) should be escaped. The correct order is to first replace each backslash with a double backslash (`\\`), then every double quote (`"`) with `\"` (since otherwise, the replacement for quotes would escape the ones we just inserted by double-escaping backslashes).

The best fix is to modify the `escapeYaml` function in scripts/content/books-json-to-md.js to first replace all backslashes in the input string (using a global regular expression `/\\/g`) with `\\`, then replace all double quotes (using `/"/g`) with `\"`. Only the function implementation at line 42 needs amending.

No library dependencies are needed. No other part of this script needs editing, and function signature and usage can remain as-is.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
